### PR TITLE
Fix: identical hash when having umlauts in URI.

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -238,7 +238,7 @@ class Redis_Page_Cache {
 	private static function parse_request_uri( $request_uri ) {
 		// Prefix the request URI with a host to avoid breaking on requests that start
 		// with a // which parse_url() would treat as containing the hostname.
-		$request_uri = 'http://null' . $request_uri;
+		$request_uri = 'http://null' . strtolower($request_uri);
 		$parsed = parse_url( $request_uri );
 
 		if ( ! empty( $parsed['query'] ) )


### PR DESCRIPTION
Safari and Chrome treats umlauts differently resulting in different hashes for the same URL:

/ein-haus-das-mitw%c3%a4chst-angerm%c3%bcnde/
/ein-haus-das-mitw%C3%A4chst-angerm%C3%BCnde/

This fix makes sure that all URI are treated as lowercase. So the above examples will result in the same hash as desired.
