### PR TITLE
Prevents PHP error for missing variable

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -116,6 +116,8 @@ class Redis_Page_Cache {
 			$expired = $cache['updated'] + self::$ttl < time();
 
 			if ( ! empty( $cache['flags'] ) ) {
+				$deleted = false;
+				
 				// Check whether any flags have been deleted.
 				if ( ! empty( $deleted_flags ) &&
 					count( array_intersect( $cache['flags'], array_keys( $deleted_flags ) ) ) > 0 ) {


### PR DESCRIPTION
Prevents PHP error for missing variable on line 129 (formerly line 127)