### PR TITLE
Update advanced-cache.php

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -230,7 +230,12 @@ class Redis_Page_Cache {
 			return self::$redis;
 
 		$redis = new Redis;
-		$connect = $redis->connect( self::$redis_host, self::$redis_port );
+                if ( ! defined( 'WP_REDIS_PATH' ) ) {
+                        $connect = $redis->connect( self::$redis_host, self::$redis_port );
+                }
+                else {
+                        $connect = $redis->connect( WP_REDIS_PATH );
+                }
 
 		if ( ! empty( self::$redis_auth ) )
 			$redis->auth( self::$redis_auth );


### PR DESCRIPTION
Allow the usage of a Unix socket to connect to Redis. The constant WP_REDIS_PATH must be defined in `/redis-page-cache-config.php`