### PR TITLE
Connection should be in try catch block...

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -230,22 +230,27 @@ class Redis_Page_Cache {
 		if ( ! class_exists( 'Redis' ) )
 			return self::$redis;
 
-		$redis = new Redis;
-		if ( self::$redis_persistent ) {
-			$connect = $redis->pconnect( self::$redis_host, self::$redis_port );
-		} else {
-			$connect = $redis->connect( self::$redis_host, self::$redis_port );
-		}
+		try {
+			$redis = new Redis;
+			if ( self::$redis_persistent ) {
+				$connect = $redis->pconnect( self::$redis_host, self::$redis_port );
+			} else {
+				$connect = $redis->connect( self::$redis_host, self::$redis_port );
+			}
 
-		if ( ! empty( self::$redis_auth ) )
-			$redis->auth( self::$redis_auth );
+			if ( ! empty( self::$redis_auth ) )
+				$redis->auth( self::$redis_auth );
 
-		if ( ! empty( self::$redis_db ) )
-			$redis->select( self::$redis_db );
+			if ( ! empty( self::$redis_db ) )
+				$redis->select( self::$redis_db );
 
-		if ( true === $connect ) {
-			$redis->setOption( Redis::OPT_SERIALIZER, Redis::SERIALIZER_PHP );
-			self::$redis = $redis;
+			if ( true === $connect ) {
+				$redis->setOption( Redis::OPT_SERIALIZER, Redis::SERIALIZER_PHP );
+				self::$redis = $redis;
+			}
+		} catch ( \Exception $e ) {
+			error_log( $e->getMessage() );
+			self::$redis = false;
 		}
 
 		return self::$redis;


### PR DESCRIPTION
Currently If redis server down or something error. Current page generation will fail and return 500.
we should put connection function inside try catch block. So It will still continue without the page cache. and record in in error_log

To reproduce. Just change the ip or port of the redis.