### PR TITLE
Adjust clear cache by url function

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -508,10 +508,10 @@ class Redis_Page_Cache {
 				$redis->set( sprintf( 'pjc-%s', self::$request_hash ), $data );
 			} else {
 				// Not okay, so delete any stale entry.
-				$redis->delete( sprintf( 'pjc-%s', self::$request_hash ) );
+				$redis->del( sprintf( 'pjc-%s', self::$request_hash ) );
 			}
 
-			$redis->delete( sprintf( 'pjc-%s-lock', self::$request_hash ) );
+			$redis->del( sprintf( 'pjc-%s-lock', self::$request_hash ) );
 			$redis->exec();
 		}
 
@@ -650,9 +650,9 @@ class Redis_Page_Cache {
 
 			$redis->multi();
 			call_user_func_array( array( $redis, 'zAdd' ), $args );
-			$redis->setTimeout( $key, self::$ttl );
+			$redis->expire( $key, self::$ttl );
 			$redis->zRemRangeByScore( $key, '-inf', $timestamp - self::$ttl );
-			$redis->zSize( $key );
+			$redis->zCard( $key );
 			list( $_, $_, $r, $count ) = $redis->exec();
 
 			// Hard-limit the data size.

--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -590,18 +590,17 @@ class Redis_Page_Cache {
 	 * @param bool $expire Expire cache by default, or delete if set to false.
 	 */
 	public static function clear_cache_by_url( $urls, $expire = true ) {
+		$blog_id = get_current_blog_id();
 		if ( is_string( $urls ) )
 			$urls = array( $urls );
 
-		foreach ( $urls as $url ) {
-			$flag = 'url:' . self::get_url_hash( $url );
+			$page_id_array = array_map(
+				function( $url ) {
+					return url_to_postid( $url );
+				}, $urls
+			);
 
-			if ( $expire ) {
-				self::$flags_expire[] = $flag;
-			} else {
-				self::$flags_delete[] = $flag;
-			}
-		}
+			self::clear_cache_by_post_id( $page_id_array, $expire );
 	}
 
 	/**


### PR DESCRIPTION
This function appeared to not be fully completed, it was adding the records using url: prefix to the expired key but in my testing that wasn't actually being looked at when loading pages added that way. Instead I determined we could get the urls page_id and then apply that to the existing clear cache_by_page_id. This will also allow us to purge a set list of URLs everytime a page or post is published to allow for dynamic pages to be more synchronous.