### PR TITLE
Add always purge urls via file override

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -508,10 +508,10 @@ class Redis_Page_Cache {
 				$redis->set( sprintf( 'pjc-%s', self::$request_hash ), $data );
 			} else {
 				// Not okay, so delete any stale entry.
-				$redis->delete( sprintf( 'pjc-%s', self::$request_hash ) );
+				$redis->del( sprintf( 'pjc-%s', self::$request_hash ) );
 			}
 
-			$redis->delete( sprintf( 'pjc-%s-lock', self::$request_hash ) );
+			$redis->del( sprintf( 'pjc-%s-lock', self::$request_hash ) );
 			$redis->exec();
 		}
 
@@ -650,9 +650,9 @@ class Redis_Page_Cache {
 
 			$redis->multi();
 			call_user_func_array( array( $redis, 'zAdd' ), $args );
-			$redis->setTimeout( $key, self::$ttl );
+			$redis->expire( $key, self::$ttl );
 			$redis->zRemRangeByScore( $key, '-inf', $timestamp - self::$ttl );
-			$redis->zSize( $key );
+			$redis->zCard( $key );
 			list( $_, $_, $r, $count ) = $redis->exec();
 
 			// Hard-limit the data size.

--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -590,18 +590,17 @@ class Redis_Page_Cache {
 	 * @param bool $expire Expire cache by default, or delete if set to false.
 	 */
 	public static function clear_cache_by_url( $urls, $expire = true ) {
+		$blog_id = get_current_blog_id();
 		if ( is_string( $urls ) )
 			$urls = array( $urls );
 
-		foreach ( $urls as $url ) {
-			$flag = 'url:' . self::get_url_hash( $url );
+			$page_id_array = array_map(
+				function( $url ) {
+					return url_to_postid( $url );
+				}, $urls
+			);
 
-			if ( $expire ) {
-				self::$flags_expire[] = $flag;
-			} else {
-				self::$flags_delete[] = $flag;
-			}
-		}
+			self::clear_cache_by_post_id( $page_id_array, $expire );
 	}
 
 	/**


### PR DESCRIPTION
Add initial iteration of adding a list of URLs to be always purged when a post or page is published. This functionality allows an environment variable to be applied with a comma delimited list of request_uri. It may be that you want to add this in as a class private static variable and have it be updated by the redis_page_cache_config array vs the environment variable usage that i am using for our docker/kubernetes deployments.

Example "/news/,/blog/"